### PR TITLE
createError 関数未定義のエラーを解消

### DIFF
--- a/packages/core/src/media/factory.ts
+++ b/packages/core/src/media/factory.ts
@@ -1,12 +1,16 @@
 import { Event, Logger } from '@skyway-sdk/common';
 
 import {
-  createError,
+  // createError,
   createWarnPayload,
   DataStreamOptions,
   LocalDataStream,
   LocalMediaStreamOptions,
 } from '..';
+
+// 以下のエラー対策として試しに utils モジュールから直接 import してみる
+// ref: https://github.com/ta14-u/inspection-skyway-js-sdk/issues/4
+import { createError } from '../util';
 import { errors } from '../errors';
 import { LocalAudioStream } from './stream/local/audio';
 import { LocalVideoStream } from './stream/local/video';


### PR DESCRIPTION
## 背景
- #4 

## 修正内容
#4 の `TypeError: (0 , __1.createError) is not a function` エラー対策として試しに createError を直接 `utils` モジュールから import するよう修正
→ この対応で上記エラーは出なくなり以下のエラーに出力が変わった
→ 以下のエラーは mediaDevices のモックを実装すれば解決できた（ https://github.com/ta14-u/inspection-skyway-js-sdk/pull/6 ）


```shell
▶ npm run test

> large-room@0.0.0 test
> jest

 PASS  src/example-const.test.ts
 FAIL  src/const.test.ts
  ● Test suite failed to run

    mediaDevicesNotFound: navigator.mediaDevicesがみつかりません

      209 |   }
      210 |
    > 211 |   return new SkyWayError({ error, info, payload: errPayload, path });
          |          ^
      212 | }
      213 |
      214 | /**@internal */

      at createError (../../packages/core/src/util.ts:211:10)
      at new StreamFactory (../../packages/core/src/media/factory.ts:34:24)
      at Object.<anonymous> (../../packages/core/src/media/factory.ts:269:36)
      at Object.<anonymous> (../../packages/core/src/index.ts:8:1)
      at Object.<anonymous> (../../packages/room/src/errors.ts:1:1)
      at Object.<anonymous> (../../packages/room/src/index.ts:1:1)
      at Object.<anonymous> (src/const.ts:1:1)
      at Object.<anonymous> (src/const.test.ts:1:1)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.948 s
Ran all test suites.
```