### PR TITLE
mediadevices のモックを追加

### DIFF
--- a/examples/large-room/__mocks__/mediaDevices.js
+++ b/examples/large-room/__mocks__/mediaDevices.js
@@ -1,0 +1,7 @@
+/* global jest */
+const mockMediaDevices = {
+  getUserMedia: jest.fn(),
+  addEventListener: jest.fn(),
+};
+
+module.exports = mockMediaDevices;

--- a/examples/large-room/jest.setup.js
+++ b/examples/large-room/jest.setup.js
@@ -1,3 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
 const RTCPeerConnectionMock = require('./__mocks__/rtcPeerConnection');
+const mediaDevicesMock = require('./__mocks__/mediaDevices');
 global.RTCPeerConnection = RTCPeerConnectionMock;
+global.navigator.mediaDevices = mediaDevicesMock;


### PR DESCRIPTION
## 背景
- #5 の結果を踏まえ、`mediaDevicesNotFound: navigator.mediaDevicesがみつかりません`エラーを解決したい

## 修正内容
- mediaDevice のモックを追加
  - => テストが通るようになった

```shell
▶ npm run test 

> large-room@0.0.0 test
> jest

 PASS  src/example-const.test.ts
 PASS  src/const.test.ts

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        4.171 s
Ran all test suites.
```

